### PR TITLE
Fix styles and make majorBlock more modular

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -131,11 +131,14 @@ footer :not(:last-child) {
 
 .majorBlock {
     border-radius: 10px;
-    padding: 10px;
-    padding-bottom: 25px;
     background-color: #5E7E5E;
     border: 2px solid #243F24;
     width: 500px;
+}
+
+.majorBlock > a {
+    display: block;
+    padding: 10px;
     min-height: 100px;
 }
 
@@ -153,6 +156,31 @@ footer :not(:last-child) {
     margin-bottom: 0px;
 }
 
+.majorBlock form {
+    display: block;
+    min-height: 40px;
+}
+
+.taskBlock {
+    border-radius: 10px;
+    padding: 10px;
+    padding-bottom: 25px;
+    background-color: #5E7E5E;
+    border: 2px solid #243F24;
+    width: 500px;
+    min-height: 100px;
+}
+
+.taskBlock h2 {
+    margin: 0px;
+    color: #000;
+}
+
+.taskBlock p {
+    color: #E2F8B6;
+    margin-bottom: 0px;
+}
+
 .subtle {
     text-decoration: none;
     color: #000000;
@@ -164,6 +192,8 @@ footer :not(:last-child) {
     border: 2px solid #1C643F;
     margin-left: 10px;
     min-height: 40px;
+    width: 75px;
+    display: inline-block;
 }
 
 .enrollButton:hover {

--- a/templates/coursePage.html
+++ b/templates/coursePage.html
@@ -15,7 +15,7 @@
             <h1>{{course.name}}</h1>
             <p>{{course.description}}</p>
             {% for task in tasks %}
-                <div class="majorBlock">
+                <div class="taskBlock">
                 <h2>{{task.name}}</h2>
                 {% if task.complete %}
                     <p>Task complete <font size="5" color="#000">&#10003;</font></p>

--- a/templates/courseTasks.html
+++ b/templates/courseTasks.html
@@ -15,7 +15,7 @@
             <h2>Tasks:</h2>
             <div>
             {% for task in tasks %}
-                <div class="majorBlock">
+                <div class="taskBlock">
                     <form id="form{{task.task_id}}" action="/tasks/{{task.task_id}}/edit/", method="post">
                         Task name:<br>
                         <input size="50" type="text" value="{{task.name}}" name="name"><br>

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -14,24 +16,7 @@
             <h1>Courses</h1>
             <div>
             {% for course in courses %}
-                <a class="subtle" href="/courses/{{course.course_id}}/editTasks"><div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                    <!--
-                    <form id="form{{course.course_id}}" action="/courses/{{course.course_id}}/edit/", method="post">
-                        Course name:<br>
-                        <input type="text" value="{{course.name}}" name="name"><br>
-                        Course description:<br>
-                        <textarea name="description">{{course.description}}</textarea><br>
-                        Course URL:<br>
-                        <input type="text" value="{{course.url}}" name="url"><br>
-                        <input type="submit" value="Update" method="post">
-                    </form>
-                    -->
-                    <form action="/courses/{{course.course_id}}/delete/", method="post">
-                        <input class="dangerButton" type="submit" value="Delete" onclick="return confirm('Are you sure you want to PERMANENTLY DELETE this course?');">
-                    </form>
-                </div></a>
+                {{ majorCard(course, false, false, false, true) }}
             {% endfor %}
             {% endblock %}
             </div>

--- a/templates/coursesPublic.html
+++ b/templates/coursesPublic.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -13,22 +15,7 @@
         <div>
             <h1>Courses</h1>
             {% for course in courses %}
-                <a class="subtle" href="/courses/{{course.course_id}}"><div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                    {% if "email" in login_session %}
-                    {% if course in enrolled_courses %}
-                    <p><font size="5" color="#000">&#10003;</font>You are enrolled in this course</p>
-                    <form action="/courses/{{course.course_id}}/unenroll/", method="post">
-                        <input class="enrollButton" type="submit" value="Unenroll" onclick="return confirm('Are you sure you want to UNENROLL from this course? You will lose all progress.');">
-                    </form>
-                    {% else %}
-                    <form action="/courses/{{course.course_id}}/enroll/", method="post">
-                        <input class="enrollButton" type="submit" value="Enroll">
-                    </form>
-                    {% endif %}
-                    {% endif %}
-                </div></a>
+                {{ majorCard(course, false, false, true, false) }}
             {% endfor %}
             {% endblock %}
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -18,7 +20,7 @@
             {% if "username" in login_session %}
             <h2>{{login_session["username"].split(" ")[0]}}'s Todo List:</h2>
             {% for task in unfinished_tasks %}
-            <div class="majorBlock">
+            <div class="taskBlock">
                 <h2>{{task.name}}</h2>
                 {% if task.complete %}
                     <p>Task complete <font size="5" color="#000">&#10003;</font></p>
@@ -37,23 +39,13 @@
             <!-- Majors -->
             <h2>{{login_session["username"].split(" ")[0]}}'s Majors:</h2>
             {% for major in enrolled_majors %}
-                <a class="subtle" href="/majors/{{major.major_id}}"><div class="majorBlock">
-                <h2>{{major.name}}</h2>
-                <p>{{major.description}}</p>
-                <p>Progress: {{major.progress}}%</p>
-                <p>Grade:</p>
-                </div></a>
+                {{ majorCard(major, true, true, false, false) }}
             {% endfor %}
             
             <!-- Courses -->
             <h2>{{login_session["username"].split(" ")[0]}}'s Courses:</h2>
             {% for course in enrolled_courses %}
-                <a class="subtle" href="/courses/{{course.course_id}}"><div class="majorBlock">
-                <h2>{{course.name}}</h2>
-                <p>{{course.description}}</p>
-                <p>Progress: {{course.progress}}%</p>
-                <p>Grade:</p>
-                </div></a>
+                {{ majorCard(course, true, true, false, false) }}
             {% endfor %}
 
             {% else %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,33 @@
+{% macro majorCard(course, showProgress, showGrade, showUI, showAdmin) %}
+    <div class="majorBlock">
+        <a class="subtle" href="/courses/{{course.course_id}}">
+            <h2>{{ course.name }}</h2>
+            <p>{{ course.description }}</p>
+            {% if showGrade %}
+                <p>Grade:</p>
+            {% endif %}
+            {% if showProgress %}
+                <p>Progress: {{ course.progress }}%</p>
+            {% endif %}
+            {% if "email" in login_session %}
+                {% if showUI %}
+                    {% if course in enrolled_courses %}
+                        <p><font size="5" color="#000">&#10003;</font>You are enrolled in this course</p>
+                        <form action="/courses/{{course.course_id}}/unenroll/" method="post">
+                            <input class="enrollButton" type="submit" value="Unenroll" onclick="return confirm('Are you sure you want to UNENROLL from this course? You will lose all progress.');">
+                        </form>
+                    {% else %}
+                        <form action="/courses/{{course.course_id}}/enroll/" method="post">
+                            <input class="enrollButton" type="submit" value="Enroll">
+                        </form>
+                    {% endif %}
+                {% endif %}
+                {% if showAdmin %}
+                    <form action="/majors/{{major.major_id}}/delete/" method="post">
+                        <input class="dangerButton" type="submit" value="Delete" onclick="return confirm('Are you sure you want to PERMANENTLY DELETE this major?');">
+                    </form>
+                {% endif %}
+            {% endif %}
+        </a>
+    </div>
+{% endmacro %}

--- a/templates/majorCourses.html
+++ b/templates/majorCourses.html
@@ -25,13 +25,7 @@
             <h2>Courses:</h2>
             <div>
             {% for course in courses %}
-                <div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                    <form action="/majors/{{major.major_id}}/courses/{{course.course_id}}/delete/", method="post">
-                        <input class="dangerButton" type="submit" value="Delete" onclick="return confirm('Are you sure you want to remove this course from the major?');">
-                    </form>
-                </div>
+                {{ majorCard(course, false, false, false, true) }}
             {% endfor %}
             {% endblock %} 
             </div>

--- a/templates/majorPage.html
+++ b/templates/majorPage.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -15,10 +17,7 @@
             <h1>{{major.name}}</h1>
             <p>{{major.description}}</p>
             {% for course in courses %}
-                <a class="subtle" href="/courses/{{course.course_id}}"><div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                </div></a>
+                {{ majorCard(course, false, false, false, false) }}
             {% endfor %}
         </div>
         {% include "footer.html" %}

--- a/templates/majors.html
+++ b/templates/majors.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -14,13 +16,7 @@
             <h1>Majors</h1>
             <div>
             {% for major in majors %}
-                <a class = "subtle"href="/majors/{{major.major_id}}/courses/"><div class="majorBlock">
-                    <h2>{{major.name}}</h2>
-                    <p>{{major.description}}</p>
-                    <form action="/majors/{{major.major_id}}/delete/", method="post">
-                        <input class="dangerButton" type="submit" value="Delete" onclick="return confirm('Are you sure you want to PERMANENTLY DELETE this major?');">
-                    </form>
-                </div></a>
+                {{ majorCard(major, false, false, false, true) }}
             {% endfor %}
             {% endblock %}
             </div>

--- a/templates/majorsPublic.html
+++ b/templates/majorsPublic.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -14,22 +16,7 @@
             <h1>Majors</h1>
             <div>
             {% for major in majors %}
-                <a class="subtle" href="/majors/{{major.major_id}}"><div class="majorBlock">
-                <h2>{{major.name}}</h2>
-                <p>{{major.description}}</p>
-                    {% if "email" in login_session %}
-                    {% if major in enrolled_majors %}
-                    <p><font size="5" color="#000">&#10003;</font>You are enrolled in this major</p>
-                    <form action="/majors/{{major.major_id}}/unenroll/", method="post">
-                        <input class="enrollButton" type="submit" value="Unenroll" onclick="return confirm('Are you sure you want to UNENROLL from this major? (This will not affect your enrolled classes)');">
-                    </form>
-                    {% else %}
-                    <form action="/majors/{{major.major_id}}/enroll/", method="post">
-                        <input class="enrollButton" type="submit" value="Enroll">
-                    </form>
-                    {% endif %}
-                    {% endif %}
-                </div></a>
+                {{ majorCard(major, false, false, true, false) }}                
             {% endfor %}
             {% endblock %}
             </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,3 +1,5 @@
+{% from "macros.html" import majorCard with context %}
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -15,37 +17,20 @@
             <img src="{{login_session['picture']}}" width=128></img>
             <h2>Enrolled Courses</h2>
                 {% for course in incomplete_courses %}
-                    <div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                    <p>Grade:</p>
-                    <p>Progress: {{course.progress}}%</p>
-                    </div>
+                    {{ majorCard(course, true, true, false, false) }}
                 {% endfor %}
             <h2>Enrolled Majors</h2>
                 {% for major in incomplete_majors %}
-                    <div class="majorBlock">
-                    <h2>{{major.name}}</h2>
-                    <p>{{major.description}}</p>
-                    <p>Progress: {{major.progress}}%</p>
-                    </div>
+                    {{ majorCard(major, true, false, false, false) }}
                 {% endfor %}
             <h2>Completed Courses</h2>
                 {% for course in complete_courses %}
-                    <div class="majorBlock">
-                    <h2>{{course.name}}</h2>
-                    <p>{{course.description}}</p>
-                    <p>Grade:</p>
-                    </div>
+                    {{ majorCard(course, false, true, false, false) }}
                 {% endfor %}
 
             <h2>Completed Majors</h2>
                 {% for major in complete_majors %}
-                    <div class="majorBlock">
-                    <h2>{{major.name}}</h2>
-                    <p>{{major.description}}</p>
-                    <p>Progress: {{major.progress}}%</p>
-                    </div>
+                    {{ majorCard(major, true, false, false, false) }}
                 {% endfor %}
 
             {% endblock %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -13,7 +13,7 @@
         <div>
             <h1>Users</h1>
             {% for user in users %}
-            <div class="majorBlock">
+            <div class="taskBlock">
                 <h2>{{user.name}}</h2>
                 <p>{{user.email}}</p>
                 <form action="/users/{{user.user_id}}/update/" method="post">


### PR DESCRIPTION
This pull request fixes style issues #34 and #32.

### Change Summary

* Move majorBlock into a macro.
* Make the clickable area of majorBlocks stay within their container.
* Stop unenroll/enroll button from overflowing its container.
* Differentiate between tasks and majors in CSS.

I decided to move majorBlock into a macro because it's used in one form or another in quite a few places and I didn't want to edit every single use every time I made a change.